### PR TITLE
[Change] Remove uppercase characters from the package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "SoapBox/Idempotency",
+    "name": "soapbox/idempotency",
     "type": "library",
     "description": "A Laravel library that manages idempotency keys for a request",
     "license": "MIT",


### PR DESCRIPTION
Package names cannot have uppercase characters on packagist.
https://packagist.org/about#naming-your-package