### PR TITLE
[Feature] Support additional response types

### DIFF
--- a/src/Idempotency.php
+++ b/src/Idempotency.php
@@ -52,6 +52,7 @@ class Idempotency
     public static function add(string $idempotencyKey, Response $response): void
     {
         if (property_exists($response, 'exception')) {
+            $response = clone $response;
             $response->exception = null;
         }
 

--- a/src/Idempotency.php
+++ b/src/Idempotency.php
@@ -2,9 +2,9 @@
 
 namespace SoapBox\Idempotency;
 
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Cache\Repository;
+use Symfony\Component\HttpFoundation\Response;
 
 class Idempotency
 {
@@ -38,32 +38,25 @@ class Idempotency
     public static function get(string $idempotencyKey): ?Response
     {
         $prefix = self::getPrefix();
-
-        if ($cached = self::getCache()->get("{$prefix}{$idempotencyKey}")) {
-            return new Response(...$cached);
-        }
-
-        return null;
+        return self::getCache()->get("{$prefix}{$idempotencyKey}");
     }
 
     /**
      * Add a response to the cache for the given key
      *
      * @param string $idempotencyKey
-     * @param \Illuminate\Http\Response $response
+     * @param \Symfony\Component\HttpFoundation\Response $response
      *
      * @return void
      */
     public static function add(string $idempotencyKey, Response $response): void
     {
-        $prefix = self::getPrefix();
+        if (property_exists($response, 'exception')) {
+            $response->exception = null;
+        }
 
-        $cached = [
-            $response->getContent(),
-            $response->getStatusCode(),
-            $response->headers->allPreserveCase(),
-        ];
-        self::getCache()->put("{$prefix}{$idempotencyKey}", $cached, config('idempotency.cache.ttl', 1440));
+        $prefix = self::getPrefix();
+        self::getCache()->put("{$prefix}{$idempotencyKey}", $response, config('idempotency.cache.ttl', 1440));
     }
 
     /**

--- a/tests/Doubles/TestSerializedCacheStore.php
+++ b/tests/Doubles/TestSerializedCacheStore.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SoapBox\Idempotency\Tests\Doubles;
+
+use Illuminate\Cache\ArrayStore;
+
+class TestSerializedCacheStore extends ArrayStore
+{
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string|array  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        $value = $this->storage[$key] ?? null;
+
+        return $value ? unserialize($value) : null;
+    }
+
+    /**
+     * Store an item in the cache for a given number of minutes.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param float|int $minutes
+     *
+     * @return void
+     */
+    public function put($key, $value, $minutes)
+    {
+        parent::put($key, serialize($value), $minutes);
+    }
+}


### PR DESCRIPTION
This uses the Symfony base request rather than the Laravel one. This will allow more response types to be serialized, for example the JsonResponse.
 
This also fixes an issue when trying to serialize a response that has an exception set on it. Some exceptions, for example the ValidationException, contain closures. When trying to serialize these exceptions they fail since closures cannot be serialized. So to avoid this issue, I just set the exception to null.

Initially I was just serializing the components of the Response to avoid these serialization issues, but now that I am serializing other response types the components that need to be serialized would be different for each response. So, it is a lot easier to just serialize the response itself. Since I was initially serializing just the response components and then rebuilding the response from that, any exception attached to the response would be lost anyway. So, unsetting the exception won't change anything on concurrent requests.